### PR TITLE
Refactor `parseDoc` function into smaller, modular functions

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,32 +40,47 @@ function parseSection(section) {
   }
 }
 
-async function parseDoc() {
-  rl.question(
-    "Enter a Wikipedia article title: ",
-    async function (articleTitle) {
-      if (!articleTitle) {
-        throw new Error("Please enter a valid Wikipedia article title");
-      }
-      let doc = await wtf.fetch(articleTitle);
-      if (!doc) {
-        throw new Error("Could not find article with that title");
-      }
-      const docJSON = doc.json();
-      docJSON.sections.forEach(parseSection);
-      if (currentChunk.length > 0) {
-        contentChunks.push(currentChunk);
-      }
-      rl.close();
-      const summaries = await Promise.all(
-        contentChunks.map(async (chunk) => {
-          const res = await api.sendMessage(chunk);
-          return res.text;
-        })
-      );
-      console.log(summaries.join("\n"));
-    }
+async function fetchArticle(articleTitle) {
+  if (!articleTitle) {
+    throw new Error("Please enter a valid Wikipedia article title");
+  }
+  const doc = await wtf.fetch(articleTitle);
+  if (!doc) {
+    throw new Error("Could not find article with that title");
+  }
+  return doc;
+}
+
+function parseSections(doc) {
+  const docJSON = doc.json();
+  docJSON.sections.forEach(parseSection);
+  if (currentChunk.length > 0) {
+    contentChunks.push(currentChunk);
+  }
+}
+
+async function summarizeContent(contentChunks) {
+  const summaries = await Promise.all(
+    contentChunks.map(async (chunk) => {
+      const res = await api.sendMessage(chunk);
+      return res.text;
+    })
   );
+  return summaries.join("\n");
+}
+
+async function parseDoc() {
+  rl.question("Enter a Wikipedia article title: ", async function (articleTitle) {
+    try {
+      const doc = await fetchArticle(articleTitle);
+      parseSections(doc);
+      rl.close();
+      const summaries = await summarizeContent(contentChunks);
+      console.log(summaries);
+    } catch (error) {
+      console.error(error.message);
+    }
+  });
 }
 
 parseDoc().catch((err) => {


### PR DESCRIPTION
Please check locally before approving this, haven't tested.